### PR TITLE
Preemptively resolves a future spec test issue.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,43 @@
-language: objective-c
+### Project specific config ###
+language: generic
+
+env:
+  global:
+    - APM_TEST_PACKAGES=""
+    - ATOM_LINT_WITH_BUNDLED_NODE="true"
+
+  matrix:
+    - ATOM_CHANNEL=stable
+    - ATOM_CHANNEL=beta
+
+os:
+  - linux
+  - osx
+
+### Generic setup follows ###
+script:
+  - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
+  - chmod u+x build-package.sh
+  - ./build-package.sh
 
 notifications:
   email:
     on_success: never
     on_failure: change
 
-script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
+branches:
+  only:
+    - master
 
 git:
   depth: 10
+
+sudo: false
+
+addons:
+  apt:
+    packages:
+    - build-essential
+    - git
+    - libgnome-keyring-dev
+    - fakeroot

--- a/README.md
+++ b/README.md
@@ -1,39 +1,58 @@
 # Multi Wrap Guide
 
 [![apm package][apm-ver-link]][releases]
-[![][travis-ci-badge]][travis-ci]
-[![][david-badge]][david]
-[![][dl-badge]][apm-pkg-link]
-[![][mit-badge]][mit]
+[![travis-ci][travis-ci-badge]][travis-ci]
+[![appveyor][appveyor-badge]][appveyor]
+[![circle-ci][circle-ci-badge]][circle-ci]
+[![david][david-badge]][david]
+[![download][dl-badge]][apm-pkg-link]
+[![mit][mit-badge]][mit]
 
 Fully customizable wrap guides at arbitrary column positions.
 
 **Wrap guides!**
 
-![guides](https://cloud.githubusercontent.com/assets/1903876/8047184/b1fc4a9c-0e07-11e5-943f-ebffd647c2e0.png)
+![guides][img-guides]
 
 **Drag 'em!**
 
-![drag](https://cloud.githubusercontent.com/assets/1903876/8047183/b1f95c24-0e07-11e5-9c53-d2e1ba4cd273.gif)
+![drag][img-drag]
 
-> Disable draggable guides by using the `Multi Wrap Guide: Toggle Lock` command. This is useful when draggable guides are interfering with text selection.
+> Disable draggable guides by using the `Multi Wrap Guide: Toggle Lock` command. This is useful when
+> draggable guides are interfering with text selection.
 
 **Create and remove 'em!**
 
-![create](https://cloud.githubusercontent.com/assets/1903876/8047182/b1f6e340-0e07-11e5-8db5-99add2af6646.gif)
+![create][img-create]
 
 ## Integration with Line Length Break
 
-The [`line-length-break`](https://atom.io/packages/line-length-break) package allows users to automatically hard break text at their editor's preferred line length. If you have this plugin installed, `multi-wrap-guide` will add a context sensitive menu item (right click on a wrap guide) that will let you line break at the selected wrap guide. Using the `Line Length Break: Break` will break at the farthest right wrap guide by default.
+The [`line-length-break`][line-length-break] package allows users to automatically hard break text
+at their editor's preferred line length. If you have this plugin installed, `multi-wrap-guide` will
+add a context sensitive menu item (right click on a wrap guide) that will let you line break at the
+selected wrap guide. Using the `Line Length Break: Break` will break at the farthest right wrap
+guide by default.
 
 ## Uninstallation
 
-<div style="background-color: #fcf2f2; border-color: #dFb5b4; border-left: 5px solid #dfb5b4; padding: 0.5em;"><p>:warning: Activating this package <strong>disables</strong> the default Atom <code>wrap-guide</code> package automatically. To go back to using the default wrap guide you'll need to deactivate or uninstall <code>multi-wrap-guide</code> <em>and then manually re-enable the <code>wrap-guide</code> package</em> in your Atom settings.</p>
-<p>Also, if you have changed your right-most vertical wrap guide since installing <code>multi-wrap-guide</code>, your <code>editor.preferredLineLength</code> will be different than from before you installed <code>multi-wrap-guide</code>. This is not a permanent change as you are of course free to change your <code>editor.preferredLineLength</code> setting before, during, and after installing this package. Note also that these changes are both global and grammar specific.</p></div>
+<div style="background-color: #FCF2F2; border-color: #DFB5B4; border-left: 5px solid #DFB5B4; padding: 0.5em;">
+<p>:warning: Activating this package <strong>disables</strong> the default Atom
+<code>wrap-guide</code> package automatically. To go back to using the default wrap guide you'll
+need to deactivate or uninstall <code>multi-wrap-guide</code> <em>and then manually re-enable the
+<code>wrap-guide</code> package</em> in your Atom settings.</p>
+<p>Also, if you have changed your right-most vertical wrap guide since installing
+<code>multi-wrap-guide</code>, your <code>editor.preferredLineLength</code> will be different than
+from before you installed <code>multi-wrap-guide</code>. This is not a permanent change as you are
+of course free to change your <code>editor.preferredLineLength</code> setting before, during, and
+after installing this package. Note also that these changes are both global and grammar
+specific.</p>
+</div>
 
 ## Configuration
 
-By default, Multi Wrap Guide will use your `editor.preferredLineLength` setting or [language specific settings](http://blog.atom.io/2014/10/31/language-scoped-config.html). You can override this by editing your `config.cson` file to provide custom settings. First open the file using the following command.
+By default, Multi Wrap Guide will use your `editor.preferredLineLength` setting or
+[language specific settings][language-specific-settings]. You can override this by editing your
+`config.cson` file to provide custom settings. First open the file using the following command.
 
 ```
 Command Palette ➔ Application: Open Your Config
@@ -51,17 +70,21 @@ Then add something like the following under the root `'*'` scope.
     ]
 ```
 
-> :warning: Note that the final column given will act as your `editor.preferredLineLength` setting. This affects things such as soft word wrap if you also have `editor.softWrapAtPreferredLineLength` enabled.
+> :warning: Note that the final column given will act as your `editor.preferredLineLength` setting.
+> This affects preferences such as soft word wrap if you also have
+> `editor.softWrapAtPreferredLineLength` enabled.
 
 ## Styling
 
-Configure styles applied to guides created by this package using your `styles.less` file. Open it with the following command.
+Configure styles applied to guides created by this package using your `styles.less` file. Open it
+with the following command.
 
 ```
 Command Palette ➔ Application: Open Your Stylesheet
 ```
 
-Then add modifications to the selectors shown below. For example, to make the guide lines purple and the tooltip green:
+Then add modifications to the selectors shown below. For example, to make the guide lines purple
+and the tooltip green:
 
 ```less
 atom-text-editor.editor {
@@ -99,7 +122,7 @@ atom-text-editor.editor {
 }
 ```
 
-![colors](https://cloud.githubusercontent.com/assets/1903876/8047181/b1ef283a-0e07-11e5-92b9-5c9afbebf29c.png)
+![colors][img-colors]
 
 ## Future Work
 
@@ -110,15 +133,26 @@ atom-text-editor.editor {
 
 [MIT][mit] © [lexicalunit][author] et [al][contributors]
 
-[mit]:              http://opensource.org/licenses/MIT
-[author]:           http://github.com/lexicalunit
-[contributors]:     https://github.com/lexicalunit/multi-wrap-guide/graphs/contributors
-[releases]:         https://github.com/lexicalunit/multi-wrap-guide/releases
-[mit-badge]:        https://img.shields.io/apm/l/multi-wrap-guide.svg
-[apm-pkg-link]:     https://atom.io/packages/multi-wrap-guide
-[apm-ver-link]:     https://img.shields.io/apm/v/multi-wrap-guide.svg
-[dl-badge]:         http://img.shields.io/apm/dm/multi-wrap-guide.svg
-[travis-ci-badge]:  https://travis-ci.org/lexicalunit/multi-wrap-guide.svg?branch=master
-[travis-ci]:        https://travis-ci.org/lexicalunit/multi-wrap-guide
-[david-badge]:      https://david-dm.org/lexicalunit/multi-wrap-guide.svg
-[david]:            https://david-dm.org/lexicalunit/multi-wrap-guide
+[mit]:                          http://opensource.org/licenses/MIT
+[author]:                       http://github.com/lexicalunit
+[contributors]:                 https://github.com/lexicalunit/multi-wrap-guide/graphs/contributors
+[releases]:                     https://github.com/lexicalunit/multi-wrap-guide/releases
+[mit-badge]:                    https://img.shields.io/apm/l/multi-wrap-guide.svg
+[apm-pkg-link]:                 https://atom.io/packages/multi-wrap-guide
+[apm-ver-link]:                 https://img.shields.io/apm/v/multi-wrap-guide.svg
+[dl-badge]:                     http://img.shields.io/apm/dm/multi-wrap-guide.svg
+[travis-ci-badge]:              https://travis-ci.org/lexicalunit/multi-wrap-guide.svg?branch=master
+[travis-ci]:                    https://travis-ci.org/lexicalunit/multi-wrap-guide
+[appveyor]:                     https://ci.appveyor.com/project/lexicalunit/multi-wrap-guide?branch=master
+[appveyor-badge]:               https://ci.appveyor.com/api/projects/status/10nasryx3of9h2lp/branch/master?svg=true
+[circle-ci]:                    https://circleci.com/gh/lexicalunit/multi-wrap-guide/tree/master
+[circle-ci-badge]:              https://circleci.com/gh/lexicalunit/multi-wrap-guide/tree/master.svg?style=shield
+[david-badge]:                  https://david-dm.org/lexicalunit/multi-wrap-guide.svg
+[david]:                        https://david-dm.org/lexicalunit/multi-wrap-guide
+[issues]:                       https://github.com/lexicalunit/multi-wrap-guide/issues
+[img-colors]:                   https://cloud.githubusercontent.com/assets/1903876/8047181/b1ef283a-0e07-11e5-92b9-5c9afbebf29c.png
+[img-create]:                   https://cloud.githubusercontent.com/assets/1903876/8047182/b1f6e340-0e07-11e5-8db5-99add2af6646.gif
+[img-drag]:                     https://cloud.githubusercontent.com/assets/1903876/8047183/b1f95c24-0e07-11e5-9c53-d2e1ba4cd273.gif
+[img-guides]:                   https://cloud.githubusercontent.com/assets/1903876/8047184/b1fc4a9c-0e07-11e5-943f-ebffd647c2e0.png
+[language-specific-settings]:   http://blog.atom.io/2014/10/31/language-scoped-config.html
+[line-length-break]:            https://atom.io/packages/line-length-break

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+### Project specific config ###
+environment:
+  APM_TEST_PACKAGES:
+  ATOM_LINT_WITH_BUNDLED_NODE: "true"
+
+  matrix:
+  - ATOM_CHANNEL: stable
+  - ATOM_CHANNEL: beta
+
+### Generic setup follows ###
+build_script:
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/atom/ci/master/build-package.ps1'))
+
+branches:
+  only:
+    - master
+
+version: "{build}"
+platform: x64
+clone_depth: 10
+skip_tags: true
+test: off
+deploy: off

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,13 @@
+dependencies:
+  override:
+    - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
+    - chmod u+x build-package.sh
+
+test:
+  override:
+    - ./build-package.sh
+
+machine:
+  environment:
+    ATOM_LINT_WITH_BUNDLED_NODE: "true"
+    APM_TEST_PACKAGES: ""

--- a/spec/multi-wrap-guide-spec.coffee
+++ b/spec/multi-wrap-guide-spec.coffee
@@ -32,7 +32,7 @@ describe "MultiWrapGuide", ->
 
   describe ".activate", ->
     it "appends a wrap guide to all existing and new editors", ->
-      expect(atom.workspace.getPanes().length).toBe 1
+      expect(atom.workspace.getTextEditors().length).toBe 1
 
       views = getWrapGuideViews()
       expect(views.length).toBe 1
@@ -43,7 +43,7 @@ describe "MultiWrapGuide", ->
       expect(getLeftPosition(guide)).toBeGreaterThan(0)
 
       atom.workspace.getActivePane().splitRight(copyActiveItem: true)
-      expect(atom.workspace.getPanes().length).toBe 2
+      expect(atom.workspace.getTextEditors().length).toBe 2
       views = getWrapGuideViews()
       expect(views.length).toBe 2
       expect(getLeftPosition(views[0].find('.multi-wrap-guide'))).toBeGreaterThan(0)


### PR DESCRIPTION
> [atom/atom#13977](https://github.com/atom/atom/pull/13977) adds multiple pane locations and updates the atom.workspace.getPanes() API to return the panes from all of them. This fixes the resultant test failures by making assertions about the number of text editors instead of the number of panes (which I think is more true to the intent of the test).

**[&mdash; @matthewwithanm][q]**

[q]: https://github.com/atom/wrap-guide/pull/66#issue-214780874